### PR TITLE
~/.ssh/config source

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.5.1</string>
 	<key>CFBundleVersion</key>
-	<string>17C</string>
+	<string>162</string>
 	<key>NSPrincipalClass</key>
 	<string>RemoteHostsSource</string>
 	<key>QSActions</key>

--- a/Info.plist
+++ b/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.5.1</string>
 	<key>CFBundleVersion</key>
-	<string>161</string>
+	<string>17C</string>
 	<key>NSPrincipalClass</key>
 	<string>RemoteHostsSource</string>
 	<key>QSActions</key>
@@ -718,6 +718,18 @@ webhost2 groups:Web
 					<key>source</key>
 					<string>SSHKeySource</string>
 				</dict>
+				<dict>
+					<key>ID</key>
+					<string>QSSSHConfigHostsSource</string>
+					<key>enabled</key>
+					<true/>
+					<key>icon</key>
+					<string>com.apple.xserve</string>
+					<key>name</key>
+					<string>SSH Config Hosts</string>
+					<key>source</key>
+					<string>SSHConfigSource</string>
+				</dict>
 			</array>
 			<key>enabled</key>
 			<true/>
@@ -752,6 +764,8 @@ webhost2 groups:Web
 		<dict>
 			<key>QSRemoteHostsSource</key>
 			<string>QSRemoteHostsSource</string>
+			<key>SSHConfigSource</key>
+			<string>SSHConfigSource</string>
 			<key>SSHKeySource</key>
 			<string>SSHKeySource</string>
 		</dict>

--- a/RemoteHosts.h
+++ b/RemoteHosts.h
@@ -15,3 +15,22 @@
 #define kDisplayHostname @"RemoteHostsDisplayHostname"
 #define kQSMetaOSType @"ostype"
 #define kQSMetaGroupMembers @"members"
+
+/**
+ * returns a predicate, that checks for valid hostnames.
+ * valid characters are a-z, 0-9, '.', and '-'
+ * must begin with a letter or digit, can contain '-', and can end with '.'
+ * in addition, allow hosts to end with colon and port number
+ */
+NSPredicate* predicateForValidHostname();
+
+/**
+ * calcs the identifier that is used for a host throughout the remote hosts plugin
+ */
+NSString* identifierForHost(NSString* host);
+
+/**
+ * sorts the NSObject-arrays alphabetical after the name
+ */
+NSMutableArray* sortQSObjects(NSMutableArray* objects);
+

--- a/RemoteHosts.h
+++ b/RemoteHosts.h
@@ -25,12 +25,16 @@
 NSPredicate* predicateForValidHostname();
 
 /**
- * calcs the identifier that is used for a host throughout the remote hosts plugin
- */
-NSString* identifierForHost(NSString* host);
-
-/**
  * sorts the NSObject-arrays alphabetical after the name
  */
 NSMutableArray* sortQSObjects(NSMutableArray* objects);
 
+/**
+ * creates a qsobject for a host and initializes the source meta data to the given string.
+ */
+QSObject* hostObjectForSource(NSString* hostName, NSString* source);
+
+/**
+ * checks if another source has already defined an entry for host.
+ */
+BOOL isFromCurrentSource(NSString* host, NSString* currentSource);

--- a/RemoteHosts.m
+++ b/RemoteHosts.m
@@ -1,0 +1,27 @@
+#import "RemoteHosts.h"
+
+NSPredicate* predicateForValidHostname() {
+  NSString *hostRegEx = @"^[a-zA-Z0-9\\-\\.]*$";
+  NSRegularExpression *regex =
+    [NSRegularExpression
+            regularExpressionWithPattern:hostRegEx
+                                 options:NSRegularExpressionUseUnixLineSeparators | NSRegularExpressionAnchorsMatchLines
+                                   error:nil];
+  return [NSPredicate predicateWithBlock:^BOOL(id evaluatedObject,
+                                               NSDictionary<NSString*,id>* bindings) {
+      return [regex firstMatchInString:evaluatedObject options:0 range:NSMakeRange(0, [evaluatedObject length])] != nil;
+    }];
+}
+
+NSString* identifierForHost(NSString* host) {
+  return [NSString stringWithFormat:@"remote-host-%@", host];
+}
+
+NSMutableArray* sortQSObjects(NSMutableArray* objects) {
+  [objects sortUsingComparator:^NSComparisonResult(id obj1, id obj2) {
+      QSObject* o1 = obj1;
+      QSObject* o2 = obj2;
+      return [[o1 name] compare:[o2 name]];
+    }];
+  return objects;
+}

--- a/RemoteHosts.m
+++ b/RemoteHosts.m
@@ -25,3 +25,25 @@ NSMutableArray* sortQSObjects(NSMutableArray* objects) {
     }];
   return objects;
 }
+
+QSObject* hostObjectForSource(NSString* hostName, NSString* source) {
+  QSObject* result = [QSObject objectWithName:hostName];
+  [result setObject:source forMeta:@"source"];
+  [result setIdentifier:identifierForHost(hostName)];
+  [result setPrimaryType:QSRemoteHostsType];
+  [result setObject:hostName forType:QSRemoteHostsType];
+
+  // this type allows paste, large type, e-mail, IM, etc
+  [result setObject:hostName forType:QSTextType];
+  return result;
+}
+
+BOOL isFromCurrentSource(NSString* hostName, NSString* source) {
+  QSObject* candidate = [QSLib objectWithIdentifier:identifierForHost(hostName)];
+  NSString* sourceOfEntry = [candidate objectForMeta:@"source"];
+  if (!sourceOfEntry) {
+    // qsobjects without source are overwritten
+    return YES;
+  }
+  return [sourceOfEntry isEqualToString:source];
+}

--- a/RemoteHosts.xcodeproj/project.pbxproj
+++ b/RemoteHosts.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		855287391BE96776003022D2 /* RemoteHosts.m in Sources */ = {isa = PBXBuildFile; fileRef = 855287381BE96776003022D2 /* RemoteHosts.m */; };
 		857EFB691BE6C71D00ABFBB3 /* SSHConfigSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 857EFB681BE6C71D00ABFBB3 /* SSHConfigSource.m */; };
 		8D1AC9700486D14A00FE50C9 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD92D38A0106425D02CA0E72 /* Cocoa.framework */; };
 		BBF5817C0B1D9D84003CFF55 /* RemoteHostsAction.m in Sources */ = {isa = PBXBuildFile; fileRef = BBF5817B0B1D9D84003CFF55 /* RemoteHostsAction.m */; };
@@ -31,6 +32,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		855287381BE96776003022D2 /* RemoteHosts.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RemoteHosts.m; sourceTree = "<group>"; };
 		857EFB671BE6C71D00ABFBB3 /* SSHConfigSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SSHConfigSource.h; sourceTree = "<group>"; };
 		857EFB681BE6C71D00ABFBB3 /* SSHConfigSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SSHConfigSource.m; sourceTree = "<group>"; };
 		8D1AC9730486D14A00FE50C9 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -126,6 +128,7 @@
 				BBF5817A0B1D9D84003CFF55 /* RemoteHostsAction.h */,
 				BBF5817B0B1D9D84003CFF55 /* RemoteHostsAction.m */,
 				E1EAB047068128A800774DFF /* RemoteHosts.h */,
+				855287381BE96776003022D2 /* RemoteHosts.m */,
 				BBF581820B1D9DC3003CFF55 /* RemoteHostsSource.h */,
 				BBF581830B1D9DC3003CFF55 /* RemoteHostsSource.m */,
 				D4E8AC4015010C22006B2D89 /* RemoteHostsPrefPane.h */,
@@ -274,6 +277,7 @@
 				BBF581840B1D9DC3003CFF55 /* RemoteHostsSource.m in Sources */,
 				857EFB691BE6C71D00ABFBB3 /* SSHConfigSource.m in Sources */,
 				D4E8AC4215010C22006B2D89 /* RemoteHostsPrefPane.m in Sources */,
+				855287391BE96776003022D2 /* RemoteHosts.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RemoteHosts.xcodeproj/project.pbxproj
+++ b/RemoteHosts.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		857EFB691BE6C71D00ABFBB3 /* SSHConfigSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 857EFB681BE6C71D00ABFBB3 /* SSHConfigSource.m */; };
 		8D1AC9700486D14A00FE50C9 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD92D38A0106425D02CA0E72 /* Cocoa.framework */; };
 		BBF5817C0B1D9D84003CFF55 /* RemoteHostsAction.m in Sources */ = {isa = PBXBuildFile; fileRef = BBF5817B0B1D9D84003CFF55 /* RemoteHostsAction.m */; };
 		BBF581840B1D9DC3003CFF55 /* RemoteHostsSource.m in Sources */ = {isa = PBXBuildFile; fileRef = BBF581830B1D9DC3003CFF55 /* RemoteHostsSource.m */; };
@@ -30,6 +31,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		857EFB671BE6C71D00ABFBB3 /* SSHConfigSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SSHConfigSource.h; sourceTree = "<group>"; };
+		857EFB681BE6C71D00ABFBB3 /* SSHConfigSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SSHConfigSource.m; sourceTree = "<group>"; };
 		8D1AC9730486D14A00FE50C9 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		8D1AC9740486D14A00FE50C9 /* Remote Hosts Plugin.qsplugin */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Remote Hosts Plugin.qsplugin"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BBF5817A0B1D9D84003CFF55 /* RemoteHostsAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoteHostsAction.h; sourceTree = "<group>"; };
@@ -129,6 +132,8 @@
 				D4E8AC4115010C22006B2D89 /* RemoteHostsPrefPane.m */,
 				D4D686241A840DC700E082E0 /* SSHKeySource.h */,
 				D4D686251A840DC700E082E0 /* SSHKeySource.m */,
+				857EFB671BE6C71D00ABFBB3 /* SSHConfigSource.h */,
+				857EFB681BE6C71D00ABFBB3 /* SSHConfigSource.m */,
 			);
 			name = Classes;
 			sourceTree = "<group>";
@@ -195,7 +200,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = NO;
-				LastUpgradeCheck = 0500;
+				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = "Skurfers' Alliance";
 			};
 			buildConfigurationList = 7F6B3EEF085CE8DF000735A8 /* Build configuration list for PBXProject "RemoteHosts" */;
@@ -267,6 +272,7 @@
 				BBF5817C0B1D9D84003CFF55 /* RemoteHostsAction.m in Sources */,
 				D4D686261A840DC700E082E0 /* SSHKeySource.m in Sources */,
 				BBF581840B1D9DC3003CFF55 /* RemoteHostsSource.m in Sources */,
+				857EFB691BE6C71D00ABFBB3 /* SSHConfigSource.m in Sources */,
 				D4E8AC4215010C22006B2D89 /* RemoteHostsPrefPane.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -278,6 +284,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D44D8094149A467C002EA077 /* QSPlugIn.xcconfig */;
 			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_ENABLE_FIX_AND_CONTINUE = YES;
 			};
 			name = Debug;
@@ -286,6 +293,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D44D8094149A467C002EA077 /* QSPlugIn.xcconfig */;
 			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_ENABLE_FIX_AND_CONTINUE = NO;
 			};
 			name = Release;
@@ -294,6 +302,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D44D8092149A467C002EA077 /* Debug.xcconfig */;
 			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				ONLY_ACTIVE_ARCH = YES;
 			};
 			name = Debug;
 		};
@@ -301,6 +311,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D44D8098149A467C002EA077 /* Release.xcconfig */;
 			buildSettings = {
+				PRODUCT_NAME = ttt;
 			};
 			name = Release;
 		};

--- a/RemoteHostsSource.m
+++ b/RemoteHostsSource.m
@@ -100,13 +100,8 @@
 			{
 				// this looks like a valid hostname
 				// build a QSObject
-				QSObject *newObject = [QSObject objectWithName:host];
-                NSString* ident = identifierForHost(host);
-				[newObject setIdentifier:ident];
-				[newObject setObject:host forType:QSRemoteHostsType];
-				// this type allows paste, large type, e-mail, IM, etc
-				[newObject setObject:host forType:QSTextType];
-				[newObject setPrimaryType:QSRemoteHostsType];
+                QSObject *newObject = hostObjectForSource(host, @"RemoteHostsSource");
+                [newObject setObject:@"RemoteHostsSource" forMeta:@"source"];
 				// add some metadata
 				if([lineParts count] > 1)
 				{
@@ -132,7 +127,7 @@
 							if (![groups objectForKey:groupName]) {
 								[groups setObject:[NSMutableArray arrayWithCapacity:1] forKey:groupName];
 							}
-							[[groups objectForKey:groupName] addObject:ident];
+							[[groups objectForKey:groupName] addObject:[newObject identifier]];
 						}
 					}
 				}

--- a/SSHConfigSource.h
+++ b/SSHConfigSource.h
@@ -1,2 +1,3 @@
+#import "RemoteHosts.h"
 @interface SSHConfigSource : QSObjectSource
 @end

--- a/SSHConfigSource.h
+++ b/SSHConfigSource.h
@@ -1,0 +1,2 @@
+@interface SSHConfigSource : QSObjectSource
+@end

--- a/SSHConfigSource.m
+++ b/SSHConfigSource.m
@@ -28,17 +28,17 @@ NSArray* hostsFromMatch(NSTextCheckingResult *result, NSString *sshConfig) {
     return res;
   }
 
+  NSString* sourceId = @"SSHConfigSource";
   [hostRegex() enumerateMatchesInString:sshConfig
                                 options:0
                                   range:NSMakeRange(0, [sshConfig length])
                              usingBlock:^(NSTextCheckingResult * match, NSMatchingFlags flags, BOOL * stop) {
       NSArray *hosts = hostsFromMatch(match, sshConfig);
       for (NSString *hostName in hosts) {
-        QSObject *hostEntry = [QSObject objectWithName:hostName];
-        [hostEntry setIdentifier:identifierForHost(hostName)];
-        [hostEntry setObject:hostName forType:QSRemoteHostsType];
-        [hostEntry setObject:hostName forType:QSTextType];
-        [hostEntry setPrimaryType:QSRemoteHostsType];
+        if (!isFromCurrentSource(hostName, sourceId)) {
+          continue;
+        }
+        QSObject *hostEntry = hostObjectForSource(hostName, [sourceId retain]);
         [hostEntry setDetails:@"Host in ~/.ssh/config"];
         [res addObject:hostEntry];
       }

--- a/SSHConfigSource.m
+++ b/SSHConfigSource.m
@@ -1,34 +1,58 @@
 #import "SSHConfigSource.h"
 
+NSString* getConfigPath() {
+  return [@"~/.ssh/config" stringByExpandingTildeInPath];
+}
+
+NSRegularExpression* hostRegex() {
+  return [NSRegularExpression
+           regularExpressionWithPattern:@"^Host (.*)$"
+                                options:NSRegularExpressionUseUnixLineSeparators | NSRegularExpressionAnchorsMatchLines
+                                  error:nil];
+}
+
+NSArray* hostsFromMatch(NSTextCheckingResult *result, NSString *sshConfig) {
+  NSString *hostsString = [sshConfig substringWithRange:[result rangeAtIndex:1]];
+  NSArray *hosts = [[hostsString componentsSeparatedByString:@" "]
+                      filteredArrayUsingPredicate:predicateForValidHostname()];
+  return hosts;
+}
+
 @implementation SSHConfigSource
 
 - (NSArray *)objectsForEntry:(NSDictionary *)theEntry {
-    NSString *sshConfigPath = [@"~/.ssh/config" stringByExpandingTildeInPath];
-    NSString* sshConfig =
-        [NSString stringWithContentsOfFile:sshConfigPath
-                                  encoding:NSUTF8StringEncoding error:nil];
+  NSString *sshConfig = [NSString stringWithContentsOfFile:getConfigPath() encoding:NSUTF8StringEncoding error:nil];
 
-    NSRegularExpression *regex =
-        [NSRegularExpression regularExpressionWithPattern:@"^Host (.*)$"
-                                                  options:NSRegularExpressionUseUnixLineSeparators | NSRegularExpressionAnchorsMatchLines
-                                                    error:nil];
+  NSMutableArray *res = [NSMutableArray array];
+  if (!sshConfig) {
+    return res;
+  }
 
-    NSMutableArray *entries = [NSMutableArray array];
-    [regex enumerateMatchesInString:sshConfig
-                            options:0
-                              range:NSMakeRange(0, [sshConfig length])
-                         usingBlock:^(NSTextCheckingResult * result, NSMatchingFlags flags, BOOL * stop) {
-            NSString* hostName = [sshConfig substringWithRange:[result rangeAtIndex:1]];
-            NSString *identifier = [NSString stringWithFormat:@"remote-host-%@", hostName];
-            QSObject* hostEntry = [QSObject objectWithName:hostName];
-            [hostEntry setIdentifier:identifier];
-            [hostEntry setObject:hostName forType:QSRemoteHostsType];
-            [hostEntry setObject:hostName forType:QSTextType];
-            [hostEntry setPrimaryType:QSRemoteHostsType];
-            [hostEntry setDetails:@"Host in ~/.ssh/config"];
-            [entries addObject:hostEntry];
-        }];
-    return  entries;
+  [hostRegex() enumerateMatchesInString:sshConfig
+                                options:0
+                                  range:NSMakeRange(0, [sshConfig length])
+                             usingBlock:^(NSTextCheckingResult * match, NSMatchingFlags flags, BOOL * stop) {
+      NSArray *hosts = hostsFromMatch(match, sshConfig);
+      for (NSString *hostName in hosts) {
+        QSObject *hostEntry = [QSObject objectWithName:hostName];
+        [hostEntry setIdentifier:identifierForHost(hostName)];
+        [hostEntry setObject:hostName forType:QSRemoteHostsType];
+        [hostEntry setObject:hostName forType:QSTextType];
+        [hostEntry setPrimaryType:QSRemoteHostsType];
+        [hostEntry setDetails:@"Host in ~/.ssh/config"];
+        [res addObject:hostEntry];
+      }
+    }];
+  return sortQSObjects(res);
 }
 
+- (BOOL)indexIsValidFromDate:(NSDate *)indexDate forEntry:(NSDictionary *)theEntry {
+  NSString* sshConfigPath = getConfigPath();
+  NSFileManager *manager = [NSFileManager defaultManager];
+  if (![manager fileExistsAtPath:sshConfigPath isDirectory:NULL]) {
+    return YES;
+  }
+  NSDate *modDate = [[manager attributesOfItemAtPath:sshConfigPath error:NULL] fileModificationDate];
+  return [modDate compare:indexDate] == NSOrderedAscending;
+}
 @end

--- a/SSHConfigSource.m
+++ b/SSHConfigSource.m
@@ -1,0 +1,34 @@
+#import "SSHConfigSource.h"
+
+@implementation SSHConfigSource
+
+- (NSArray *)objectsForEntry:(NSDictionary *)theEntry {
+    NSString *sshConfigPath = [@"~/.ssh/config" stringByExpandingTildeInPath];
+    NSString* sshConfig =
+        [NSString stringWithContentsOfFile:sshConfigPath
+                                  encoding:NSUTF8StringEncoding error:nil];
+
+    NSRegularExpression *regex =
+        [NSRegularExpression regularExpressionWithPattern:@"^Host (.*)$"
+                                                  options:NSRegularExpressionUseUnixLineSeparators | NSRegularExpressionAnchorsMatchLines
+                                                    error:nil];
+
+    NSMutableArray *entries = [NSMutableArray array];
+    [regex enumerateMatchesInString:sshConfig
+                            options:0
+                              range:NSMakeRange(0, [sshConfig length])
+                         usingBlock:^(NSTextCheckingResult * result, NSMatchingFlags flags, BOOL * stop) {
+            NSString* hostName = [sshConfig substringWithRange:[result rangeAtIndex:1]];
+            NSString *identifier = [NSString stringWithFormat:@"remote-host-%@", hostName];
+            QSObject* hostEntry = [QSObject objectWithName:hostName];
+            [hostEntry setIdentifier:identifier];
+            [hostEntry setObject:hostName forType:QSRemoteHostsType];
+            [hostEntry setObject:hostName forType:QSTextType];
+            [hostEntry setPrimaryType:QSRemoteHostsType];
+            [hostEntry setDetails:@"Host in ~/.ssh/config"];
+            [entries addObject:hostEntry];
+        }];
+    return  entries;
+}
+
+@end


### PR DESCRIPTION
hi .. i have a lot of hosts in my ~/.ssh/config. sometimes i even have the same host but with different users in config, so the known host source, is not picking those up.
for this i created a simple source, that hardcoded uses ~/.ssh/config to scan through Host entries and puts them to your excellent remote hosts plugin.

in the process i also updated the xcode project files. this makes the change a little bigger than it must be.
